### PR TITLE
624 receive text messages bug fix

### DIFF
--- a/force-app/main/default/classes/SummitEventsReadShared.cls
+++ b/force-app/main/default/classes/SummitEventsReadShared.cls
@@ -51,7 +51,7 @@ public without sharing class SummitEventsReadShared {
                         Phone_Label__c, Phone_Type_Label__c, Preferred_First_Name_Label__c, Pronouns_Label__c, Registrant_Receive_Texts_Label__c,
                         Relationship_To_Institution_Label__c, Third_Party_Registrant_Label__c, Title_Label__c, Preferred_Class_Year_Label__c,
                         Registrant_Relationship_Label__c, Event_Fee_Label__c, Event_Fee_Total_Label__c, Event_Fee_Submit_List_Label__c, Account__r.Name,
-                        Filter_Category__c, Do_not_show_receive_text_question__c, Add_Info_Question_Pick_List_Long_1__c, Add_Info_Question_Pick_List_Long_2__c,
+                        Filter_Category__c, Do_not_show_receive_text_question__c, Ask_Receive_Text_Messages__c, Add_Info_Question_Pick_List_Long_1__c, Add_Info_Question_Pick_List_Long_2__c,
                         Add_Info_Question_Pick_List_Long_3__c, Add_Info_Question_Pick_List_Long_4__c, Add_Info_Question_Pick_List_Long_5__c, Event_Status__c,
                         reCAPTCHA_v3_Score_Fail_Text__c, reCAPTCHA__c, Ask_Dietary_Restrictions__c, Dietary_Restrictions_Label__c, Accessibility_Detail_Label__c,
                         Accessibility_Label__c, Ask_Accessibility_Needs__c, Display_Guest_Registration__c, Payment_Gateway__c, Event_Additional_Question_Title__c,

--- a/force-app/main/default/layouts/Summit_Events__c-Summit Event Default Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events__c-Summit Event Default Layout.layout-meta.xml
@@ -395,6 +395,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>Ask_Receive_Text_Messages__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>Private_Event__c</field>
             </layoutItems>
             <layoutItems>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Ask_Receive_Text_Messages__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Ask_Receive_Text_Messages__c.field-meta.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Ask_Receive_Text_Messages__c</fullName>
+    <description>Ask the registrant for their permission to receive text messages.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Ask the registrant for their permission to receive text messages.</inlineHelpText>
+    <label>Ask Receive Text Messages</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Do not ask</fullName>
+                <default>true</default>
+                <label>Do not ask</label>
+            </value>
+            <value>
+                <fullName>Ask</fullName>
+                <default>false</default>
+                <label>Ask</label>
+            </value>
+            <value>
+                <fullName>Ask and require</fullName>
+                <default>false</default>
+                <label>Ask and require</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -460,14 +460,17 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                             </apex:outputPanel>
 
                             <!-- TEXT MESSAGE ASK -->
-                            <apex:outputPanel layout="block" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1" rendered="{!IF((CONTAINS(eventPage.Ask_Phone__c, 'mobile') || eventPage.Ask_Phone__c == 'Ask mobile' || eventPage.Ask_Phone__c == 'Ask mobile and require' ||  phoneType='mobile') && !eventPage.Do_not_show_receive_text_question__c, true, false)}">
+                            <apex:outputPanel layout="block" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1" rendered="{!IF((CONTAINS(eventPage.Ask_Phone__c, 'mobile') || eventPage.Ask_Phone__c == 'Ask mobile' || eventPage.Ask_Phone__c == 'Ask mobile and require' ||  phoneType='mobile') && eventPage.Ask_Receive_Text_Messages__c != 'Do not ask', true, false)}">
                                 <div class="slds-form-element">
                                     <div class="slds-form-element__control">
                                         <div class="slds-checkbox">
                                             <apex:inputCheckbox value="{!eventRegistration.Registrant_Receive_Texts__c}" id="AcceptTextMessage"/>
                                             <apex:outputLabel for="AcceptTextMessage" styleClass="slds-checkbox__label">
                                                 <span class="slds-checkbox_faux"></span>
-                                                <span class="slds-form-element__label">{!eventPage.Registrant_Receive_Texts_Label__c} <abbr class="slds-required" title="required">*</abbr></span>
+                                                {!eventPage.Registrant_Receive_Texts_Label__c}
+                                                <apex:outputText escape="false" rendered="{!IF(eventPage.Ask_Receive_Text_Messages__c == 'Ask and require', true, false)}">
+                                                    <span class="slds-form-element__label"> <abbr class="slds-required" title="required">*</abbr></span>
+                                                </apex:outputText>
                                             </apex:outputLabel>
                                         </div>
                                     </div>

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -461,18 +461,22 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
 
                             <!-- TEXT MESSAGE ASK -->
                             <apex:outputPanel layout="block" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1" rendered="{!IF((CONTAINS(eventPage.Ask_Phone__c, 'mobile') || eventPage.Ask_Phone__c == 'Ask mobile' || eventPage.Ask_Phone__c == 'Ask mobile and require' ||  phoneType='mobile') && eventPage.Ask_Receive_Text_Messages__c != 'Do not ask', true, false)}">
-                                <div class="slds-form-element">
+                                <div class="slds-form-element {!IF(eventPage.Ask_Receive_Text_Messages__c == 'Ask and require', 'slds-is-required', '')}">
                                     <div class="slds-form-element__control">
-                                        <div class="slds-checkbox">
-                                            <apex:inputCheckbox value="{!eventRegistration.Registrant_Receive_Texts__c}" id="AcceptTextMessage"/>
+                                        <span class="slds-checkbox">
+                                            <apex:inputCheckbox value="{!eventRegistration.Registrant_Receive_Texts__c}" id="AcceptTextMessage" styleClass="slds-checkbox__input"/>          
                                             <apex:outputLabel for="AcceptTextMessage" styleClass="slds-checkbox__label">
                                                 <span class="slds-checkbox_faux"></span>
-                                                {!eventPage.Registrant_Receive_Texts_Label__c}
-                                                <apex:outputText escape="false" rendered="{!IF(eventPage.Ask_Receive_Text_Messages__c == 'Ask and require', true, false)}">
-                                                    <span class="slds-form-element__label"> <abbr class="slds-required" title="required">*</abbr></span>
-                                                </apex:outputText>
+                                                <span class="slds-form-element__label">{!eventPage.Registrant_Receive_Texts_Label__c}
+                                                    <apex:outputText escape="false" rendered="{!IF(eventPage.Ask_Receive_Text_Messages__c == 'Ask and require', true, false)}">
+                                                        <abbr class="slds-required" title="required">*</abbr>
+                                                    </apex:outputText>
+                                                </span>
                                             </apex:outputLabel>
-                                        </div>
+                                        </span>
+                                    </div>
+                                    <div class="slds-form-element__help" id="acceptTextMessage-required">
+                                        {!IF(eventPage.Ask_Receive_Text_Messages__c == 'Ask and require', 'This field is required', '')}
                                     </div>
                                 </div>
                             </apex:outputPanel>

--- a/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
@@ -1888,6 +1888,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Summit_Events__c.Ask_Receive_Text_Messages__c</field>
+        <readable>true</readable>
+    </fieldPermissions>    
+    <fieldPermissions>
         <editable>true</editable>
         <field>Summit_Events__c.Audience__c</field>
         <readable>true</readable>

--- a/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
@@ -1767,6 +1767,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Summit_Events__c.Ask_Receive_Text_Messages__c</field>
+        <readable>true</readable>
+    </fieldPermissions>    
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Summit_Events__c.Audience__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/staticresources/SummitEventsAssets/js/register.js
+++ b/force-app/main/default/staticresources/SummitEventsAssets/js/register.js
@@ -97,7 +97,7 @@ function checkForm() {
     let error_count = 0;
     let emailReg = /^([a-zA-Z0-9_.\-.'.+])+@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,4})+$/;
 
-    document.querySelectorAll(".slds-is-required .slds-input, .slds-is-required .slds-textarea, .slds-is-required .slds-select").forEach(item => {
+    document.querySelectorAll(".slds-is-required .slds-input, .slds-is-required .slds-textarea, .slds-is-required .slds-select, .slds-is-required .slds-checkbox").forEach(item => {
         let inputWrap = item.closest('.slds-form-element');
         let inputRequired = inputWrap.classList.contains('slds-is-required');
         if (item) {
@@ -106,7 +106,11 @@ function checkForm() {
                 inputType = item.type.toLowerCase();
             }
 
-            if (inputRequired && !item.value) {
+            if(item.className == 'slds-checkbox'){                
+                item.value = item.firstChild.checked ? true : false;
+            }
+
+            if (inputRequired && !item.value) {            
                 inputWrap.classList.add("slds-has-error");
                 addErrorFixerListener(item, inputWrap, 'change');
                 error_count++;


### PR DESCRIPTION
# Critical Changes

- Read Access given to Summit_Events_Admin and Summit_Events_Registrant
- New code in checkForm() from register.js to validate checkbox
- "Do not ask" value by default

# Changes

- New picklist field called "Ask Receive Text Messages" (Ask_Receive_Text_Messages__c)
- Ask_Receive_Text_Messages__c values:
  - Do not ask
  - Ask
  - Ask and require
- New way but following patterns to render required fields in SummitEventsRegister page ( TEXT MESSAGE ASK section )

# Issues Closed
#624 
